### PR TITLE
Update class-creativecommons-button.php

### DIFF
--- a/includes/class-creativecommons-button.php
+++ b/includes/class-creativecommons-button.php
@@ -5,13 +5,12 @@ class CreativeCommonsButton
 
     const CCL_BUTTON_HEAD = '<div class="cc-attribution-element"><button class="cc-attribution-button cc-attribution-copy-button" data-clipboard-action="copy" data-clipboard-text="" ';
 
-    const CCL_BUTTON_TAIL = '"><span class="cc-attribution-copy-button-label" data-l10n-id="Share">Copy credit as</span>'
-                         . '</button><div class="cc-dropdown-wrapper"><button class="cc-attribution-button cc-attribution-format-select">HTML &#x25BC;</button>
+	const CC_BUTTON_TAIL = '"><span data-l10n-id="Share">Share</span></button>
+<div class="cc-dropdown-wrapper"><button class="cc-attribution-format-select">HTML &#x25BC;</button>
 <ul class="cc-dropdown-menu" aria-haspopup="true" aria-expanded="false">
     <li class="cc-dropdown-menu-item cc-dropdown-menu-item-selected"><a class="cc-dropdown-menu-item-link cc-format-html-rdfa" data-cc-format="html-rdfa" href="#">HTML</a></li>
     <li class="cc-dropdown-menu-item"><a class="cc-dropdown-menu-item-link cc-format-text" data-cc-format="text" href="#">Text</a></li></ul></div>
-<button class="cc-attribution-button cc-attribution-help-button" data-l10n-id="?">?</button></div>';
-
+<button class="cc-attribution-help-button" data-l10n-id="?">?</button></div>';
     
     private static $instance = null;
 


### PR DESCRIPTION
There is no need for concatenation on `const CC_BUTTON_TAIL =...` and until I changed I was generating fatal errors on my site.

![fatal](https://cloud.githubusercontent.com/assets/463038/22079666/eb0db2f6-dd79-11e6-80da-5d2539076f25.jpg)
