### PR TITLE
Fix PHP >= 7 deprecation warning

### DIFF
--- a/widgets/creativecommons-widget.php
+++ b/widgets/creativecommons-widget.php
@@ -7,8 +7,7 @@ if(! class_exists('CreativeCommons_widget')) {
 
         private $localization_domain = 'CreativeCommons';
 
-
-        function CreativeCommons_widget()
+        function __construct()
         {
             /* Widget settings. */
             $widget_ops = array(
@@ -23,7 +22,7 @@ if(! class_exists('CreativeCommons_widget')) {
             );
 
             /* Create the widget. */
-            $this->__construct(
+            parent::__construct(
                 'license-widget',
                 __('License', $this->localization_domain),
                 $widget_ops,


### PR DESCRIPTION
2.1-beta release throws a deprecation warning in PHP >= 7 because of its use of a constructor method with the same name as the class in `creativecommons-widget.php`. This PR fixes the issue by using a `__construct()` method with `parent::__construct()` as seen [here](https://codex.wordpress.org/Widgets_API#Default_Usage).