### PR TITLE
Fix 49: Missing 'license' at end

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
-# Creative Commons plugin for WordPress
+# creativecommons-wordpress-plugin
+
+Creative Commons plugin for WordPress
 
 This is a WordPress plugin to assist you to choose a
 Creative Commons license for your blog or website.
+
 
 ## Credits
 
 Main development work by:
 
-* Tarmo Toikkanen
-* Bjorn Wijers
+- Tarmo Toikkanen
+- Bjorn Wijers
 
 On behalf of Creative Commons:
 
-* Matt Lee
+- Matt Lee
+
 
 ## Contribute
 
@@ -24,50 +28,54 @@ to hackers@creativecommons.org
 Download the latest version:
 [release-2.0](https://github.com/creativecommons/wordpress-plugin/releases/tag/release-2.0)
 
-## Features 
+
+## Features
 
 - License your blog (single WordPress install)
 - License your WordPress Network (WordPress Multisite install)
 - License some of your sites differently in your WordPress Network
 - License all your content with the same license (license per author)
-- License some posts or page differently from your default license (per content license) 
-- Prevent license changes in your WordPress Network (all content on all sites need to use the same license)
-- Prevent license changes per site (all content on a site must use the same license) 
+- License some posts or page differently from your default license (per content
+  license)
+- Prevent license changes in your WordPress Network (all content on all sites
+  need to use the same license)
+- Prevent license changes per site (all content on a site must use the same
+  license)
 
-At this moment the plugin allows you to license WordPress content such as posts and pages but no media files (yet).
+At this moment the plugin allows you to license WordPress content such as posts
+and pages but no media files (yet).
 
-*Possible future features*
 
-Here's a list of some features we'd love to add to this
-plugin or support in a separate (child) plugin. If
-you'd like these or other features to be implemented
-you may consider supporting this plugin with code
-contributions, testing or funding Creative Commons for
-further development.
+### Possible future features
 
-- Allow media files to be licensed 
+Here's a list of some features we'd love to add to this plugin or support in a
+separate (child) plugin. If you'd like these or other features to be
+implemented you may consider supporting this plugin with code contributions,
+testing or funding Creative Commons for further development.
+
+- Allow media files to be licensed
 
 - Allow to search (using external search engines) for
   specific Creative Commons licensed media files
 
-## History 
 
-This plugin is loosely based on an existing, but
-seemingly abandoned WordPress plugin named 'License' (a
-component of the
-[MIT Educational Collaboration Space](http://ecs.mit.edu)
-project) by mitcho (Michael Yoshitaka Erlewine) & Brett
-Mellor. We're also inspired by Creative Commons'
-original WPLicense plugin written by former Creative
-Commons CTO Nathan Yergler.
+## History
+
+This plugin is loosely based on an existing, but seemingly abandoned WordPress
+plugin named 'License' (a component of the [MIT Educational Collaboration
+Space][collabspace] project) by mitcho (Michael Yoshitaka Erlewine) and
+Brett Mellor. We're also inspired by Creative Commons' original
+[wordpress-cc-plugin][oldplugin] written by former Creative Commons CTO Nathan
+ Yergler.
+
+[collabspace]:http://cispace.mit.edu/
+[oldplugin]:https://github.com/cc-archive/wordpress-cc-plugin
 
 
 ## Development
 
-If you're interested in the code have a look at the
-master branch for the releases. Development will be
-done in the development branch.
+If you're interested in the code have a look at the master branch for the
+releases. Development will be done in the development branch.
 
-Occasionally other branches may be available to test
-new features or play with new ideas, but they may be
-deleted anytime so don't rely on those branches.
+Occasionally other branches may be available to test new features or play with
+new ideas, but they may be deleted anytime so don't rely on those branches.

--- a/wplicense.php
+++ b/wplicense.php
@@ -8,15 +8,15 @@ Plugin URI: http://wiki.creativecommons.org/WpLicense
 License: GPLv2 or later versions
 */
 
-if( ! class_exists('WPLicense') ) { 
+if( ! class_exists('WPLicense') ) {
   class WPLicense {
 
     // MAKE SURE THE PLUGIN HEADER HAS THE SAME VERSION NUMBER!
-    const VERSION = '2.0-beta'; 
+    const VERSION = '2.0-beta';
 
-    private $plugin_url; 
+    private $plugin_url;
     private $localization_domain = 'WPLicense';
-    private $locale; 
+    private $locale;
 
     function __construct() {
       $this->plugin_url =  WP_PLUGIN_URL .'/' . str_replace( basename( __FILE__ ), "", plugin_basename( __FILE__ ) );
@@ -25,12 +25,12 @@ if( ! class_exists('WPLicense') ) {
       $this->locale = get_locale();
       $mo     = dirname(__FILE__) . '/languages/' . $this->locale . '.mo';
       load_textdomain($this->localization_domain, $mo);
-      
-      // add admin.js to wp-admin pages and displays the site license settings 
-      // in the Settings->General settings page unless you're running WordPress 
-      // Multisite (Network) and the superadmin has disabled this.  
+
+      // add admin.js to wp-admin pages and displays the site license settings
+      // in the Settings->General settings page unless you're running WordPress
+      // Multisite (Network) and the superadmin has disabled this.
       add_action( 'admin_init', array(&$this, 'license_admin_init') );
-  
+
 
 
       // Selecting a license for individual posts or pages is only possible if the settings of the site allow it
@@ -41,18 +41,18 @@ if( ! class_exists('WPLicense') ) {
         add_action( 'save_post',                   array(&$this, 'save_license') );
       }
 
-      // Selecting a license as a user for all your content is only possible if the settings of the site allow it, 
+      // Selecting a license as a user for all your content is only possible if the settings of the site allow it,
       // by default it will allow it.
       if( $this->allow_user_override_site_license() ) {
         add_action( 'personal_options',            array(&$this, 'user_license_settings_html') );
         add_action( 'personal_options_update',     array(&$this, 'save_license') );
       }
-      
+
       // this implements the license plugin as a widget.
-      // TODO: Widget needs more testing with the new approach 
+      // TODO: Widget needs more testing with the new approach
       add_action( 'widgets_init', array(&$this, 'license_as_widget') );
-    
-      // if the plugin is installed in multisite environment allow to set the 
+
+      // if the plugin is installed in multisite environment allow to set the
       // options for all sites as default from the network options
       if( is_multisite() ) {
         add_action('wpmu_options', array(&$this, 'network_license_settings_html') , 10, 0);
@@ -65,13 +65,13 @@ if( ! class_exists('WPLicense') ) {
       add_settings_section( 'license-section', 'License Settings', array(&$this, 'settings_license_section'), 'general', 'license-section');
 
       add_settings_field( 'license', '<label for="license">' . __('License your site', $this->localization_domain) . '</label>', array(&$this, 'setting_license_field'), 'general', 'license-section');
-      
+
       add_settings_field( 'warning_txt', '<label for="warning_txt">' . __('Add license warning text', $this->localization_domain) . '</label>', array(&$this, 'setting_warning_field'), 'general', 'license-section');
-      
+
       add_settings_field( 'attribution_to', '<label for="attribution_to">' . __('Set attribution to', $this->localization_domain) . '</label>', array(&$this, 'setting_attribution_field'), 'general', 'license-section');
       add_settings_field( 'allow_user_override', '<label for="allow_user_override">' . __('Allow users override site license', $this->localization_domain) . '</label>', array(&$this, 'setting_user_override_license_field'), 'general', 'license-section');
       add_settings_field( 'allow_content_override', '<label for="allow_content_override">' . __('Allow license per post or page', $this->localization_domain) . '</label>', array(&$this, 'setting_content_override_license_field'), 'general', 'license-section');
-    
+
     }
 
     function settings_license_section() {
@@ -82,7 +82,7 @@ if( ! class_exists('WPLicense') ) {
     function setting_license_field() {
       $this->select_license_html( $location = 'site', $echo = true );
     }
-    
+
     function setting_warning_field() {
       $license = $this->get_license( $location = 'site');
       $w = esc_html( $license['warning_txt'] );
@@ -99,7 +99,7 @@ if( ! class_exists('WPLicense') ) {
       $checked = ( array_key_exists('user_override_license', $license) ) ? checked( $license['user_override_license'], 'true', false ) : '';
       echo "<input name='license[user_override_license]' type='checkbox' " . $checked . " id='user-override-license' value='true' />";
     }
-    
+
     // only used once in site admin
     function setting_content_override_license_field() {
       $license = $this->get_license( $location = 'site');
@@ -107,30 +107,30 @@ if( ! class_exists('WPLicense') ) {
       echo "<input name='license[content_override_license]' type='checkbox' " . $checked . " id='content-override-license' value='true' />";
     }
 
-    /** 
+    /**
      * Check if a site may override the network license.
      *
-     * If a network license override is allowed, a site admin may change their 
-     * site's license. The rights are cascading: if a site admin may change a 
-     * site's license, she may also allow a user to select their own license. 
-     * if a site admin may not change the license she will also not be allowed 
-     * to let a user pick their own license. A siteadmin may also enable to 
+     * If a network license override is allowed, a site admin may change their
+     * site's license. The rights are cascading: if a site admin may change a
+     * site's license, she may also allow a user to select their own license.
+     * if a site admin may not change the license she will also not be allowed
+     * to let a user pick their own license. A siteadmin may also enable to
      * have a license per content.
      *
-     * @return bool true if the network license override is allowed, false 
+     * @return bool true if the network license override is allowed, false
      * otherwise
      */
     function allow_site_override_network_license() {
       $license = $this->get_license( $location = 'network' );
-      // gotcha: using true as string instead of bool since it will be a string value 
+      // gotcha: using true as string instead of bool since it will be a string value
       // returned from the settings form
       if( 'true' == $license['site_override_license'] ) {
         return true;
       } else {
         return false;
-      }  
+      }
     }
-    
+
     function allow_user_override_site_license() {
       if( is_multisite() && ! $this->allow_site_override_network_license() ) {
         return false;
@@ -161,19 +161,19 @@ if( ! class_exists('WPLicense') ) {
 
     /**
      * Set a default license.
-     * 
+     *
      * Hierarchy of license selection
-     * If the plugin is used in a Multisite Network WordPress setup there is an 
-     * option added to the network options to set a default license for all 
-     * sites in this particular network. Each site will inherit this default. 
-     * A sit owner may change this license (at least if the Multisite Admin 
-     * allows it). On a site level (or single WordPress install) an admin may 
-     * allow this site default license to be changed. If the site allows a 
-     * user may change the default license for her/his posts. The same goes for 
-     * posts/pages: if the site admin allows it these can be changed per post 
-     * or page.  
-     * 
-     * 
+     * If the plugin is used in a Multisite Network WordPress setup there is an
+     * option added to the network options to set a default license for all
+     * sites in this particular network. Each site will inherit this default.
+     * A sit owner may change this license (at least if the Multisite Admin
+     * allows it). On a site level (or single WordPress install) an admin may
+     * allow this site default license to be changed. If the site allows a
+     * user may change the default license for her/his posts. The same goes for
+     * posts/pages: if the site admin allows it these can be changed per post
+     * or page.
+     *
+     *
      **/
     function plugin_default_license() {
       $this->_logger('Got default settings');
@@ -195,29 +195,29 @@ if( ! class_exists('WPLicense') ) {
     }
 
 
-    
-    
-    // 1) Check if it's allowed to have a license per content => check the 
+
+
+    // 1) Check if it's allowed to have a license per content => check the
     // content for a license. No license found or not allowed? Continue 2
-    // 2) Check if it's allowed to have a license per user => check the 
-    // content author and grab his/her license preference. No license found 
+    // 2) Check if it's allowed to have a license per user => check the
+    // content author and grab his/her license preference. No license found
     // or user are not allowed to choose their own license? Continue 3
     // 3) Check if the site is part of a network => No? continue step 4a
     // Yes? continue step 4b
-    // 4a) the site is NOT part of a network => Get license from options or 
-    // return plugin's default 
-    // 4b) The site is part of a network => check if the site may choose it's 
-    // own license => check the options for a license. Not allowed or no 
+    // 4a) the site is NOT part of a network => Get license from options or
+    // return plugin's default
+    // 4b) The site is part of a network => check if the site may choose it's
+    // own license => check the options for a license. Not allowed or no
     // license found Continue step 5
-    // 5) Check the multisite options for a license and return if not found 
-    // return plugin default     
+    // 5) Check the multisite options for a license and return if not found
+    // return plugin default
     function get_license( $location = null ) {
       switch ($location) {
         case 'network' :
           $this->_logger('called network');
           $license = ( $network_license = get_site_option( 'license' ) ) ? $network_license : $this->plugin_default_license();
           break;
-        
+
         case 'site':
           $this->_logger('called site');
           if( is_multisite() ) {
@@ -239,15 +239,15 @@ if( ! class_exists('WPLicense') ) {
           $license = ( $post_page_license = $this->get_post_page_license() ) ? $post_page_license : $this->get_license( 'profile' );
           break;
 
-        // TODO need to check default structure below since this can cause way 
-        // too many calls for the right license   
+        // TODO need to check default structure below since this can cause way
+        // too many calls for the right license
         case 'frontend':
           $this->_logger('get license for the frontend');
           if( is_multisite() ) {
             $this->_logger('get license: multisite');
             $license = $this->get_license( 'network' );
             $this->_logger('got network license');
-            if( $this->allow_site_override_network_license() ) { 
+            if( $this->allow_site_override_network_license() ) {
               $this->_logger('site may override network license');
               $license = $this->get_license( 'site' );
               $site_license = $license; // keep track of site license cause we need to check it twice...
@@ -256,10 +256,10 @@ if( ! class_exists('WPLicense') ) {
                 $this->_logger('user may override license');
                 $license = $this->get_license( 'profile' );
                 $this->_logger('got user license');
-              } 
+              }
               if( array_key_exists('content_override_license', $site_license) && 'true' == $site_license['content_override_license'] ) {
                 $this->_logger('content may override license');
-                $license = $this->get_license( 'post-page' ); 
+                $license = $this->get_license( 'post-page' );
                 $this->_logger('got content license');
               }
             }
@@ -267,50 +267,50 @@ if( ! class_exists('WPLicense') ) {
             $license = $this->get_license( 'site' );
             if( array_key_exists( 'user_override_license', $license ) && 'true' == $license['user_override_license'] ) {
               $license = $this->get_license( 'profile' );
-            } 
+            }
             if( array_key_exists('content_override_license', $license) && 'true' == $license['content_override_license'] ) {
-              $license = $this->get_license( 'post-page' ); 
+              $license = $this->get_license( 'post-page' );
             }
           }
           break;
-      } 
+      }
       return $license;
     }
 
 
-    // will use a variable prefix with underscore to make *really* sure this 
-    // postmeta value will NOT be displayed to other users. The option is the 
+    // will use a variable prefix with underscore to make *really* sure this
+    // postmeta value will NOT be displayed to other users. The option is the
     // same structure as everywhere: a serialized array.
     // (http://codex.wordpress.org/Function_Reference/add_post_meta)
     function get_post_page_license() {
       global $post; // TODO check if this can be done without a global and if we're always getting what we want
-      $license = get_post_meta( $post->ID, '_license', true ); 
+      $license = get_post_meta( $post->ID, '_license', true );
       if( is_array($license) && sizeof($license) > 0 ) {
         return $license;
-      } else { 
-        return false; 
-      } 
+      } else {
+        return false;
+      }
     }
 
 
 
-    // used in: 
+    // used in:
     // - network settings
-    // - site settings 
-    // - profile settings (personal & others) 
+    // - site settings
+    // - profile settings (personal & others)
     // - post/page edit screen (my own & others)
     function select_license_html( $location = null, $echo = true ) {
       // get the previously selected license from this site's options or the plugin's default license
       //$license = get_option('license', $this->plugin_default_license() );
       $license  = $this->get_license( $location );
-      // add lang option 
+      // add lang option
       $lang = ( isset($this->locale) && ! empty($this->locale) ) ? 'lang=' . esc_attr($this->locale) : '';
 
       $html = '';
       $html .= "<span id='license-display'></span>";
       $html .= '<br id="license"><a title="' . __('Choose a Creative Commons license', $this->localization_domain) . '" class="thickbox edit-license" href="http://creativecommons.org/choose/?';
         $html .= 'partner=WordPress+License+Plugin&';
-        $html .= $lang;  
+        $html .= $lang;
         $html .= '&exit_url=' . $this->plugin_url . 'licensereturn.php?url=[license_url]%26name=[license_name]%26button=[license_button]%26deed=[deed_url]&';
         $html .= '&KeepThis=true&TB_iframe=true&height=500&width=600">' . __('Change license', $this->localization_domain);
       $html .=  '</a>';
@@ -319,7 +319,7 @@ if( ! class_exists('WPLicense') ) {
       $html .= '<input type="hidden" value="'.$license['image'].'" id="hidden-license-image" name="license[image]"/>';
       $html .= '<input type="hidden" value="'.$license['name'].'" id="hidden-license-name" name="license[name]"/>';
       if( $echo ) {
-        echo $html; 
+        echo $html;
       } else {
         return $html;
       }
@@ -329,16 +329,16 @@ if( ! class_exists('WPLicense') ) {
     // return default attribution options
     function get_attribution_options( $location ) {
       switch ( $location ) {
-      
+
       case 'network':
           $attribution_options = array(
-            'network_name' => sprintf( __('The network name: %s', $this->localization_domain), get_site_option('site_name') ), 
+            'network_name' => sprintf( __('The network name: %s', $this->localization_domain), get_site_option('site_name') ),
             'site_name'    => __("A site's name", $this->localization_domain),
             'display_name' => __('The author display name', $this->localization_domain),
             'other'        => __('Something completely differrent', $this->localization_domain)
           );
         break;
-        
+
         case 'site':
           $attribution_options = array(
             'site_name'    => sprintf( __('The site name: %s', $this->localization_domain), get_bloginfo('site') ),
@@ -347,24 +347,24 @@ if( ! class_exists('WPLicense') ) {
           );
         break;
 
-        default: 
+        default:
           if( $this->allow_user_override_site_license() ) {
             $attribution_options = array(
               'display_name' => __('The author display name', $this->localization_domain),
               'other'        => __('Something completely differrent', $this->localization_domain)
             );
-          }            
+          }
         break;
       }
-      
-      return $attribution_options;     
+
+      return $attribution_options;
     }
 
 
 
 
     function select_attribute_to_html( $location = null, $echo = true ) {
-      $license = $this->get_license( $location ); 
+      $license = $this->get_license( $location );
       $attribute_options = $this->get_attribution_options( $location );
 
 
@@ -377,9 +377,9 @@ if( ! class_exists('WPLicense') ) {
           $html .= "<label for='$id'><input type='radio' class='license-attribution-options' id='$id' $checked name='license[attribute_to]' value='$attr_val' />" . $attr_text . "</label><br/>\n";
         }
         if ( 'other' == $license['attribute_to'] ) {
-          $class = ''; 
+          $class = '';
           $value = esc_html( $license['attribute_other'] );
-          $url   = esc_url ( $license['attribute_other_url']);        
+          $url   = esc_url ( $license['attribute_other_url']);
         } else {
           $class = 'hidden'; // hide the other input text field if the 'other' option is not ticked
           $value = '';
@@ -392,7 +392,7 @@ if( ! class_exists('WPLicense') ) {
         $html .= '</p>';
       }
       if( $echo ) {
-        echo $html; 
+        echo $html;
       } else {
         return $html;
       }
@@ -402,11 +402,11 @@ if( ! class_exists('WPLicense') ) {
     // add a warning text at the site/network settings
     function display_settings_warning( $echo = false ) {
       $html = '';
-      $html .= '<p>'; 
-      $html .= __('WARNING: Changing these license settings after content has been added may change the licenses authors on the site have selected, effectively relicensing possibly all content on the site!', $this->localization_domain);   
+      $html .= '<p>';
+      $html .= __('WARNING: Changing these license settings after content has been added may change the licenses authors on the site have selected, effectively relicensing possibly all content on the site!', $this->localization_domain);
       $html .= '</p>';
       if( $echo ) {
-        echo $html; 
+        echo $html;
       } else {
         return $html;
       }
@@ -414,15 +414,15 @@ if( ! class_exists('WPLicense') ) {
 
 
 
-    /** 
-     * Renders the license settings WordPress Network Settings page 
+    /**
+     * Renders the license settings WordPress Network Settings page
      *
-     * Using the settings rendered by this function a superadmin may set a 
-     * default license for the WordPress Network. This will be used for all 
+     * Using the settings rendered by this function a superadmin may set a
+     * default license for the WordPress Network. This will be used for all
      * sites. If the superadmin allows it, siteadmins may change their site's
      * license and choose a different license than the default Network license.
      *
-     * Called by wpmu_options action 
+     * Called by wpmu_options action
      *
      **/
     function network_license_settings_html() {
@@ -430,7 +430,7 @@ if( ! class_exists('WPLicense') ) {
       // get the previously selected license from the network options or the plugin's default license
       //$license = get_site_option('license', $this->plugin_default_license() );
       $location = 'network';
-      $license = $this->get_license( $location ); 
+      $license = $this->get_license( $location );
 
 
       $html  = '';
@@ -442,8 +442,8 @@ if( ! class_exists('WPLicense') ) {
       $html .= "<tbody>\n";
 
 
-      $html .= $this->_license_settings_html( $location ); 
-      
+      $html .= $this->_license_settings_html( $location );
+
       $html .= "<tr valign='top'>\n";
       $html .= "\t<th scope='row'><label for='override-license'>" .  __("Allow siteadmins to change their site's license", $this->localization_domain) . "</label></th>\n";
       $html .= "\t<td><input name='site_override_license' type='checkbox'" . checked( $license['site_override_license'], 'true', false ) . " id='site_override-license' value='true' />";
@@ -452,50 +452,50 @@ if( ! class_exists('WPLicense') ) {
 
       $html .= "</tbody>\n";
       $html .= "</table>\n";
-      
+
       echo $html;
     }
 
     // save license from network settings, user profile and post/page interface
     function save_license( $post_id = false ) {
-      if( isset($_POST['license_wpnonce']) && wp_verify_nonce( $_POST['license_wpnonce'], 'license-update') ) { 
+      if( isset($_POST['license_wpnonce']) && wp_verify_nonce( $_POST['license_wpnonce'], 'license-update') ) {
         if ( defined('IS_PROFILE_PAGE') && IS_PROFILE_PAGE) {
           $this->_save_user_license();
         } elseif( is_multisite() && defined('WP_NETWORK_ADMIN') && WP_NETWORK_ADMIN ) {
           $this->_save_network_license();
         } else {
           // presume we're in a post or page wp-admin environment
-          // might need to deal with autosave 
-          
+          // might need to deal with autosave
+
           $this->_save_post_page_license( $post_id );
         }
-      } else { 
+      } else {
         return $post_id;
       }
     }
 
 
-    // wrapper so I can use the _verify_license_data function. 
-    // @TODO refactor in the future 
+    // wrapper so I can use the _verify_license_data function.
+    // @TODO refactor in the future
     public function _wrapper_settings_api_verify( $data ) {
       return $this->_verify_license_data( 'site', $data );
     }
 
 
     // check the data before saving it
-    // use $from ala get_license to determine where the data is coming from 
+    // use $from ala get_license to determine where the data is coming from
     // and what should be mandatory return an array or WP_Error?
     private function _verify_license_data( $from, $data = null ) {
-      
+
       $license = array();
 
       // if no data was provided assume the data is in $_POST['license']
-      if( is_null($data) && isset( $_POST['license'] ) ) { 
-        $data = $_POST['license']; 
+      if( is_null($data) && isset( $_POST['license'] ) ) {
+        $data = $_POST['license'];
       }
-      
+
       $license['version']          = self::VERSION; // always save the current version
-      $license['deed']             = esc_url(  $data['deed']  ); 
+      $license['deed']             = esc_url(  $data['deed']  );
       $license['image']            = esc_url(  $data['image'] );
       $license['name']             = esc_attr( $data['name']  );
       $license['attribute_to']     = esc_attr( $data['attribute_to'] );
@@ -508,9 +508,9 @@ if( ! class_exists('WPLicense') ) {
             $license['site_override_license'] = esc_attr( $_POST['site_override_license'] );
           }
           break;
-        case 'site': 
+        case 'site':
           $license['user_override_license']    = esc_attr( $data['user_override_license'] );
-          $license['content_override_license'] = esc_attr( $data['content_override_license'] );  
+          $license['content_override_license'] = esc_attr( $data['content_override_license'] );
           $license['warning_txt']              = esc_html( $data['warning_txt'] );
         break;
       }
@@ -521,13 +521,13 @@ if( ! class_exists('WPLicense') ) {
 
     // validates & verifies the data and then saves the license in the site_options
     private function _save_network_license( ) {
-      $license = $this->_verify_license_data( $from = 'network' ); 
+      $license = $this->_verify_license_data( $from = 'network' );
       return update_site_option('license', $license);
     }
 
-    // TODO: need to decide if the user option is global for all 
-    // sites/blogs in a network. Also need to make sure that we're using 
-    // the current profile user_id which might not be the 
+    // TODO: need to decide if the user option is global for all
+    // sites/blogs in a network. Also need to make sure that we're using
+    // the current profile user_id which might not be the
     // current_user (e.g. admin changing license for a user).
     // validates & verifies the data and then saves the license in the user_options
     private function _save_user_license( ) {
@@ -536,9 +536,9 @@ if( ! class_exists('WPLicense') ) {
       return update_user_option( $user_id, 'license', $license, $global = false );
     }
 
-    // save post/page metadata due to it being an array it should not be shown 
+    // save post/page metadata due to it being an array it should not be shown
     // in the post or page custom fields interface
-    // using _license to hide it from the custom fields 
+    // using _license to hide it from the custom fields
     private function _save_post_page_license( $post_id ) {
       $license = $this->_verify_license_data( $from = 'post-page' );
       return update_post_meta( $post_id,  '_license', $license);
@@ -551,8 +551,8 @@ if( ! class_exists('WPLicense') ) {
       wp_enqueue_script("thickbox");
       wp_enqueue_style("thickbox");
       wp_enqueue_script('license');
-      // if a siteadmin may change her site's license, show the settings 
-      // otherwise don't bother 
+      // if a siteadmin may change her site's license, show the settings
+      // otherwise don't bother
       if( is_multisite() ) {
         if( $this->allow_site_override_network_license() ) {
           $this->register_site_settings();
@@ -562,32 +562,32 @@ if( ! class_exists('WPLicense') ) {
       }
     }
 
-    
-    // render the html settings for the user profile 
-    // TODO: add global option: if allowed use this license across all my sites 
+
+    // render the html settings for the user profile
+    // TODO: add global option: if allowed use this license across all my sites
     // in this network.
     function user_license_settings_html(){
       $location = 'profile';
       $html     = wp_nonce_field('license-update', $name = 'license_wpnonce', $referer = true, $echo = false);
-      $html     .= $this->_license_settings_html( $location); 
+      $html     .= $this->_license_settings_html( $location);
       echo $html;
-    } 
-    
+    }
+
     function post_page_license_settings_html(){
       $location = 'post-page';
       $html  = '<div id="license" class="misc-pub-section misc-pub-section-last ">';
       $html .= wp_nonce_field('license-update', $name = 'license_wpnonce', $referer = true, $echo = false);
       $html .= '<strong>' . __('Licensed:', $this->localization_domain) . '</strong>';
-      
+
       $html .= '<p>';
-      $html .= $this->select_license_html( $location, $echo = false );  
+      $html .= $this->select_license_html( $location, $echo = false );
       $html .= '</p>';
-      
+
       $html .= '<p>';
       $html .= $this->select_attribute_to_html( $location, $echo = false );
       $html .= '</p>';
       $html .= '</div>';
-      
+
       echo $html;
     }
 
@@ -609,20 +609,20 @@ if( ! class_exists('WPLicense') ) {
       $html .= $this->select_attribute_to_html( $location, $echo = false );
       $html .= "</td>\n";
       $html .= "</tr>\n";
-      
+
       return $html;
     }
 
 
 
 
-    // add filters to this function so themers can easily change the html 
+    // add filters to this function so themers can easily change the html
     // output
     public function print_license_html( $location = 'frontend', $echo = true ) {
-      // TODO if the license is shown on a multiple items page (except the author 
-      // archive page?) display the site (or network default license) 
-      // default license including a warning that individual items may be 
-      // licensed differently.  
+      // TODO if the license is shown on a multiple items page (except the author
+      // archive page?) display the site (or network default license)
+      // default license including a warning that individual items may be
+      // licensed differently.
       // add a filter to include the license with the excerpt & content filter
       // allow an option to switch this off
 
@@ -630,7 +630,7 @@ if( ! class_exists('WPLicense') ) {
       $license = $this->get_license( $location );
       $html = '';
       if( is_array($license) && sizeof($license) > 0 ) {
-        $deed_url      = esc_url( $license['deed'] ); 
+        $deed_url      = esc_url( $license['deed'] );
         $image_url     = esc_url( $license['image'] );
         $license_name  = esc_html( $license['name'] );
         $warning       = (array_key_exists( 'warning_txt', $license ) ) ?  esc_html( $license['warning_txt'] ) : ''; // needs check
@@ -640,19 +640,19 @@ if( ! class_exists('WPLicense') ) {
           $attribute_text = isset( $attribution['text'] ) ? $attribution['text'] : '';
           $attribute_url  = isset( $attribution['url'] ) ? $attribution['url'] : '';
         }
-      
 
-        // it's a single entity so use the post->title otherwise use the site's 
-        // title and add a warning that multiple items might have different 
+
+        // it's a single entity so use the post->title otherwise use the site's
+        // title and add a warning that multiple items might have different
         // licenses.
         if( is_singular() ) {
           global $post;
-          if( is_object( $post ) ) { 
+          if( is_object( $post ) ) {
             $title_work = esc_html( $post->post_title );
             $warning_text = '';
-          }  
+          }
         } else {
-          $title_work   = get_bloginfo( 'name' );   
+          $title_work   = get_bloginfo( 'name' );
 	  $attribute_url = esc_html(site_url());
           $warning_text = "<p class='license-warning'>" . esc_html( $warning ) . "</p>";
         }
@@ -661,13 +661,13 @@ if( ! class_exists('WPLicense') ) {
         $html .= "<a rel='license' href='$deed_url'>";
         $html .= "<img alt='" . __('Creative Commons License', $this->localization_domain) . "' style='border-width:0' src='$image_url' />";
         $html .= "</a><br />";
-        $html .= "<span xmlns:dct='http://purl.org/dc/terms/' property='dct:title'>$title_work</span> "; 
+        $html .= "<span xmlns:dct='http://purl.org/dc/terms/' property='dct:title'>$title_work</span> ";
 	if (is_singular()) {
 	        $html .= __('by', $this->localization_domain);
-		$html .= " <a xmlns:cc='http://creativecommons.org/ns#' href='$attribute_url' property='cc:attributionName' rel='cc:attributionURL'>$attribute_text</a> "; 
+		$html .= " <a xmlns:cc='http://creativecommons.org/ns#' href='$attribute_url' property='cc:attributionName' rel='cc:attributionURL'>$attribute_text</a> ";
 	}
 	$html .= sprintf( __('is licensed under a <a rel="license" href="%s">%s</a>.', $this->localization_domain), $deed_url, $license_name );
-	//$html .= '<br />'; 
+	//$html .= '<br />';
         //$html .= __('Based on a work at <a xmlns:dct="http://purl.org/dc/terms/" href="http://source.url" rel="dct:source">http://source.url</a>.', $this->localization_domain);
         //$html .='<br />';
         //$html .= __('Permissions beyond the scope of this license may be available at <a xmlns:cc="http://creativecommons.org/ns#" href="http://morepermissions.url" rel="cc:morePermissions">http://morepermissions.url</a>.', $this->localization_domain);
@@ -685,7 +685,7 @@ if( ! class_exists('WPLicense') ) {
     // log all errors if wp_debug is active
     private function _logger( $string ) {
       if( defined('WP_DEBUG') && (WP_DEBUG == true) ) {
-        error_log( $string ); 
+        error_log( $string );
       } else {
         return;
       }
@@ -693,40 +693,40 @@ if( ! class_exists('WPLicense') ) {
 
     private function _get_attribution( $license ) {
       if( is_array($license) && sizeof( $license ) > 0 ){
-        $attribution_option = isset( $license['attribute_to'] ) ? $license['attribute_to'] : null;  
+        $attribution_option = isset( $license['attribute_to'] ) ? $license['attribute_to'] : null;
       }
 
       $attribution = array();
 
-      switch($attribution_option) { 
-      
-        case 'network_name': 
+      switch($attribution_option) {
+
+        case 'network_name':
           $attribution['text'] = esc_html( get_site_option('site_name') );
           $attribution['url']  = esc_url( get_permalink() );
           break;
 
-        case 'site_name': 
+        case 'site_name':
           $attribution['text'] = esc_html( get_bloginfo('site') );
           $attribution['url']  = esc_url( get_permalink() );
           break;
 
-        case 'display_name': 
+        case 'display_name':
 	  // If displaying multiple posts, the display_name (author) will be reverted to site name later.
 	  $attribution['text'] = esc_html(get_the_author_meta('display_name'));
 	  $attribution['url'] = esc_url(get_permalink());
           break;
 
-        case 'other': 
+        case 'other':
           $other = isset( $license['attribute_other'] ) ? $license['attribute_other'] : '';
           $other_url = isset( $license['attribute_other_url'] ) ? $license['attribute_other_url'] : '';
-          
+
           $attribution['text'] = esc_html( $other );
           $attribution['url']  = esc_url( $other_url );
           break;
       }
-      return $attribution; 
-    }  
-    
+      return $attribution;
+    }
+
     function license_as_widget() {
       require_once('widgets/wplicense_widget.php');
       register_widget( 'WPLicense_widget' );
@@ -734,5 +734,5 @@ if( ! class_exists('WPLicense') ) {
   }
   $license = new WPLicense();
 } else {
-  $this->_logger('Could not instantiate class WPLicense due to already existing class WPLicense.'); 
+  $this->_logger('Could not instantiate class WPLicense due to already existing class WPLicense.');
 }

--- a/wplicense.php
+++ b/wplicense.php
@@ -182,7 +182,7 @@ if( ! class_exists('WPLicense') ) {
         'image'                    => 'http://i.creativecommons.org/l/by-sa/4.0/88x31.png',
         'attribute_to'             => '',
         'title'                    => get_bloginfo('name'),
-        'name'                     => 'Creative Commons Attribution-Share Alike 4.0 License',
+        'name'                     => 'Creative Commons Attribution-Share Alike 4.0',
         'sitename'                 => get_bloginfo(''),
         'siteurl'                  => get_bloginfo('url'),
         'author'                   => get_bloginfo(),
@@ -666,7 +666,7 @@ if( ! class_exists('WPLicense') ) {
 	        $html .= __('by', $this->localization_domain);
 		$html .= " <a xmlns:cc='http://creativecommons.org/ns#' href='$attribute_url' property='cc:attributionName' rel='cc:attributionURL'>$attribute_text</a> ";
 	}
-	$html .= sprintf( __('is licensed under a <a rel="license" href="%s">%s</a>.', $this->localization_domain), $deed_url, $license_name );
+	$html .= sprintf( __('is licensed under a <a rel="license" href="%s">%s</a> License.', $this->localization_domain), $deed_url, $license_name );
 	//$html .= '<br />';
         //$html .= __('Based on a work at <a xmlns:dct="http://purl.org/dc/terms/" href="http://source.url" rel="dct:source">http://source.url</a>.', $this->localization_domain);
         //$html .='<br />';


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #49

**Description**
- changed `print_license_html()` to include the text "License" as the name of CC licenses doesn't include the word "License".
- removed the word "License" from the default license name
- removed trailing spaces according to wordpress coding standards (I have no idea how those white spaces got there)