### PR TITLE
Fix 49: Missing 'license' at end

### DIFF
--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -366,7 +366,7 @@ class CreativeCommons {
             'image'                    => 'https://licensebuttons.net/l/by-sa/4.0/88x31.png',
             'attribute_to'             => '',
             'title'                    => get_bloginfo('name'),
-            'name'                     => 'Creative Commons Attribution-Share Alike 4.0 License',
+            'name'                     => 'Creative Commons Attribution-Share Alike 4.0',
             'sitename'                 => get_bloginfo(''),
             'siteurl'                  => get_bloginfo('url'),
             'author'                   => get_bloginfo(),
@@ -1087,7 +1087,7 @@ class CreativeCommons {
                 $html .= $attribute_text;
             }
         }
-        $html .= sprintf(__('is licensed under a <a rel="license" href="%s">%s</a>.', $this->localization_domain), $deed_url, $license_name);
+        $html .= sprintf(__('is licensed under a <a rel="license" href="%s">%s</a> License.', $this->localization_domain), $deed_url, $license_name);
         if ($source_work_url) {
             $html .= '<br />';
             $html .= sprintf(__('Based on a work at <a xmlns:dct="http://purl.org/dc/terms/" href="%s" rel="dct:source">%s</a>.', $this->localization_domain), $source_work_url, $source_work_url);

--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -14,13 +14,13 @@ class CreativeCommons {
     private $locale;
 
     private static $instance = null;
-    
+
 
     private function __construct()
     {
     }
 
-    
+
     public function init()
     {
         $this->plugin_url = plugin_dir_url(dirname(__FILE__));
@@ -92,20 +92,20 @@ class CreativeCommons {
             );
         }
     }
-    
+
 
     public static function get_instance()
     {
- 
+
         if ( null == self::$instance ) {
             self::$instance = new self;
         }
- 
+
         return self::$instance;
- 
+
     }
-    
-    
+
+
     function wphub_register_settings()
     {
         add_option('wphub_use_api', '1');
@@ -129,7 +129,7 @@ class CreativeCommons {
     /**
      * Register and add settings
      */
-        
+
     public function page_init()
     {
         register_setting(
@@ -199,7 +199,7 @@ class CreativeCommons {
             'license-section',
             array('label_for' => 'allow_user_override')
         );
-            
+
         add_settings_field(
             'allow_content_override',
              __(
@@ -729,7 +729,7 @@ class CreativeCommons {
         ) {
             $data = $_POST['license'];
         }
-        
+
         // always save the current version
         $license['version']          = self::VERSION;
         $license['deed']             = esc_url( $data['deed'] );
@@ -739,7 +739,7 @@ class CreativeCommons {
         $license['attribute_other']  = esc_html($data['attribute_other' ]);
         $license['attribute_other_url']
             = esc_html($data['attribute_other_url']);
-        
+
         switch($from) {
             // @TODO need to check this!
         case 'network':
@@ -1103,7 +1103,7 @@ class CreativeCommons {
         return $html;
     }
 
-    
+
     public function cc0_html_rdfa($title_work, $attribute_url, $attribute_text)
     {
         $result = '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
@@ -1178,7 +1178,7 @@ class CreativeCommons {
         register_widget('CreativeCommons_widget');
     }
 
-        
+
     // log all errors if wp_debug is active
     private function _logger($string)
     {
@@ -1188,5 +1188,5 @@ class CreativeCommons {
             return;
         }
     }
-        
+
 }


### PR DESCRIPTION
Fixes #49

**Description**
- changed `print_license_html()` to include the text "License" as the name of CC licenses doesn't include the word "License".
- removed the word "License" from the default license name
- removed trailing spaces according to WordPress coding standards (I have no idea how those white spaces got there)